### PR TITLE
[DM-28601] More thorough cache checking

### DIFF
--- a/src/cachemachine/types.py
+++ b/src/cachemachine/types.py
@@ -1,7 +1,7 @@
 """Helper types and errors for cachemachine."""
 
 from abc import ABC, abstractmethod
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from typing import Dict, List, Optional
 
 
@@ -13,6 +13,15 @@ class DockerRegistryError(Exception):
 
 class KubernetesDaemonsetNotFound(Exception):
     """Kubernetes daemonset does not exist."""
+
+    pass
+
+
+class KubernetesImageHashNotFound(Exception):
+    """Internal exception when looking through the cache.
+
+    This happens when an image hash entry isn't available,
+    but we always need the hash."""
 
     pass
 
@@ -94,6 +103,23 @@ class DockerImageList(list):
         This list can be easily converted to JSON.
         """
         return [asdict(i) for i in self]
+
+
+@dataclass
+class ImageEntry:
+    """Container for an entry in the cache from kubernetes.
+
+    Since we build this up over a loop, we might have one part first,
+    then the other part, so all of these are optional.  Call valid
+    when you think you are done to check that you have all the parts
+    you need.
+    """
+
+    """SHA256 image hash of the image entry."""
+    image_hash: Optional[str] = None
+
+    """List of tags the image is known by."""
+    tags: List[str] = field(default_factory=list)
 
 
 class KubernetesLabels(dict):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,6 +57,7 @@ def sleep_noop() -> Generator:
 pretend hashes.  Note, hashes aren't the correct length, but that
 doesn't matter."""
 mock_registry = {
+    "prepuller_pulled_recommended": "sha256:b0b7d97ff9d62ccd049",
     "recommended": "sha256:b0b7d97ff9d62ccd049",
     "r21_0_0": "sha256:b0b7d97ff9d62ccd049",
     "w_2021_03": "sha256:bb16e5ea71bd7139779",
@@ -71,7 +72,7 @@ def docker_mock() -> Generator:
     """Use the mock docker client."""
     with patch("cachemachine.rubinrepoman.DockerClient") as mock:
         mock.return_value = DockerMock(mock_registry)
-        yield
+        yield mock.return_value
 
 
 @pytest.fixture
@@ -80,4 +81,4 @@ def kubernetes_mock() -> Generator:
     kube_mock = KubernetesMock(mock_registry)
     with patch("cachemachine.cachemachine.KubernetesClient") as mock:
         mock.return_value = kube_mock
-        yield
+        yield mock.return_value


### PR DESCRIPTION
So docker caches from kubernetes point of view are organized by
the hashes, and not by the names or where they are pulled.  So if
you retagged an image and pushed it, it would show up next to it.

So first, undo what I did before, which loosened the restrictions
but wasn't exactly perfect.  Make the tests better to add the images
to look the same.  Add a test to the pull test that pretends to be
the prepuller to add things to the cache.  Then make sure everything
is fine.