### PR TITLE
[DM-28601] Loosen up hash checks

### DIFF
--- a/src/cachemachine/cachemachine.py
+++ b/src/cachemachine/cachemachine.py
@@ -11,7 +11,6 @@ from cachemachine.types import (
     DockerImageList,
     ImageEntry,
     KubernetesDaemonsetNotFound,
-    KubernetesImageHashNotFound,
     KubernetesLabels,
     RepoMan,
 )
@@ -133,8 +132,8 @@ class CacheMachine:
                             other_tags.remove(t)
 
                             if ie.image_hash is None:
-                                raise KubernetesImageHashNotFound(
-                                    f"{repository} with tags {ie.tags}"
+                                logger.debug(
+                                    f"{repository} : {ie.tags} has no hash"
                                 )
                             else:
                                 node_images.append(

--- a/src/cachemachine/types.py
+++ b/src/cachemachine/types.py
@@ -17,15 +17,6 @@ class KubernetesDaemonsetNotFound(Exception):
     pass
 
 
-class KubernetesImageHashNotFound(Exception):
-    """Internal exception when looking through the cache.
-
-    This happens when an image hash entry isn't available,
-    but we always need the hash."""
-
-    pass
-
-
 class CacheMachineNotFoundError(Exception):
     """Cachemachine does not exist."""
 


### PR DESCRIPTION
So, sometimes apparently there is a set of images that don't have
a hash coming out of kubernetes.  At least on Google.  I'm not
sure why this doesn't have a hash, maybe it's not pushed somewhere
or something.

Here's the entry of the troublesome freeloader:

    - names:
      - gke.gcr.io/kube-proxy-amd64:v1.18.12-gke.1205
      - k8s.gcr.io/kube-proxy-amd64:v1.18.12-gke.1205
      sizeBytes: 120890453

This is gotten by running kubectl get nodes -o yaml